### PR TITLE
feat: create proxy-only subnet in modules/frontend and add CI build,  readme and metadata files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.23
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -77,9 +77,10 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display'
 
 # Generate metadata
 .PHONY: docker_generate_metadata_w_display

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 6840s
+steps:
+- id: swap-module-refs
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && module-swapper']
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+- id: init-all
+  waitFor:
+    - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run all --stage init --verbose']
+# separate frontend and backend module for http load balancer
+- id: apply lb-http-separate-frontend-and-backend
+  waitFor:
+    - init-all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestCloudRunRegionalLb --stage apply --verbose']
+- id: verify lb-http-separate-frontend-and-backend
+  waitFor:
+    - apply lb-http-separate-frontend-and-backend
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'sleep 720 && cft test run TestCloudRunRegionalLb --stage verify --verbose']
+- id: teardown lb-http-separate-frontend-and-backend
+  waitFor:
+    - verify lb-http-separate-frontend-and-backend
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestCloudRunRegionalLb --stage teardown --verbose']
+tags:
+- 'ci'
+- 'integration'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.23'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- id: 'lint'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/usr/local/bin/test_lint.sh']
+tags:
+- 'ci'
+- 'lint'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.23'

--- a/examples/cloud-run/README.md
+++ b/examples/cloud-run/README.md
@@ -1,0 +1,20 @@
+# HTTP Regional Load Balancer Example - Separate modules for creating HTTP load balancer frontend and backend resources
+
+This example creates a global HTTP forwarding rule to forward traffic to cloud run service. The `google_compute_region_backend_service` and its dependencies are created as part of `backend` module.
+The forwarding rules and its dependecies are created as part of `frontend` modules.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | n/a | `string` | n/a | yes |
+| region | n/a | `string` | `"us-central1"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external\_ip | The IP address of the forwarding rule |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,10 @@ spec:
     source:
       repo: https://github.com/googlestaging/terraform-google-regional-lb-http.git
       sourceType: git
+    version: 0.0.1
     actuationTool:
       flavor: Terraform
-      version: ">= 1.0.0"
+      version: ">= 1.3"
     description: {}
   content:
     subBlueprints:
@@ -35,40 +36,239 @@ spec:
       - name: frontend
         location: modules/frontend
     examples:
-      - name: test-regional-lb
-        location: examples/test-regional-lb
+      - name: cloud-run
+        location: examples/cloud-run
   interfaces:
     variables:
       - name: name
-        description: Name for the forwarding rule and prefix for supporting resources
+        description: Name for the backend service.
         varType: string
         required: true
-      - name: backend_service_name
-        description: The name of the backend service
+      - name: project_id
+        description: The project to deploy to, if not set the default provider project is used.
         varType: string
         required: true
       - name: region
-        description: The region where the load balancer will be created
-        varType: string
-        defaultValue: us-central1
-      - name: url_map
-        description: The URL map to associate with the proxy
+        description: The region where the load balancer backend service will be created
         varType: string
         required: true
-      - name: proxy_name
-        description: The name of the HTTP proxy
+      - name: load_balancing_scheme
+        description: Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL_MANAGED for Envoy-based load balancer, and INTERNAL_SELF_MANAGED for traffic director)
         varType: string
-        required: true
-      - name: forwarding_rule_name
-        description: The name of the forwarding rule
+        defaultValue: EXTERNAL_MANAGED
+      - name: protocol
+        description: The protocol this BackendService uses to communicate with backends.
         varType: string
-        required: true
+        defaultValue: HTTP
+      - name: port_name
+        description: Name of backend port. The same name should appear in the instance groups referenced by this service. Required when the load balancing scheme is EXTERNAL.
+        varType: string
+        defaultValue: http
+      - name: description
+        description: Description of the backend service.
+        varType: string
+      - name: connection_draining_timeout_sec
+        description: Time for which instance will be drained (not accept new connections, but still work to finish started).
+        varType: number
+      - name: enable_cdn
+        description: Enable Cloud CDN for this BackendService.
+        varType: bool
+        defaultValue: false
+      - name: session_affinity
+        description: "Type of session affinity to use. Possible values are: NONE, CLIENT_IP, CLIENT_IP_PORT_PROTO, CLIENT_IP_PROTO, GENERATED_COOKIE, HEADER_FIELD, HTTP_COOKIE, STRONG_COOKIE_AFFINITY."
+        varType: string
+      - name: affinity_cookie_ttl_sec
+        description: Lifetime of cookies in seconds if session_affinity is GENERATED_COOKIE.
+        varType: number
+      - name: locality_lb_policy
+        description: The load balancing algorithm used within the scope of the locality.
+        varType: string
+      - name: security_policy
+        description: Security policy in string.
+        varType: string
+      - name: timeout_sec
+        description: This has different meaning for different type of load balancing. Please refer https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+        varType: number
+      - name: health_check
+        description: Input for creating HttpHealthCheck or HttpsHealthCheck resource for health checking this BackendService. A health check must be specified unless the backend service uses an internet or serverless NEG as a backend.
+        varType: |-
+          object({
+              host                = optional(string, null)
+              request_path        = optional(string, null)
+              request             = optional(string, null)
+              response            = optional(string, null)
+              port                = optional(number, null)
+              port_name           = optional(string, null)
+              proxy_header        = optional(string, null)
+              port_specification  = optional(string, null)
+              protocol            = optional(string, null)
+              check_interval_sec  = optional(number, 10)
+              timeout_sec         = optional(number, 10)
+              healthy_threshold   = optional(number, 2)
+              unhealthy_threshold = optional(number, 2)
+              logging             = optional(bool, true)
+            })
+      - name: firewall_networks
+        description: Names of the networks to create firewall rules in
+        varType: list(string)
+        defaultValue:
+          - default
+      - name: firewall_projects
+        description: Names of the projects to create firewall rules in
+        varType: list(string)
+        defaultValue:
+          - default
+      - name: target_tags
+        description: List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified.
+        varType: list(string)
+        defaultValue: []
+      - name: target_service_accounts
+        description: List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified.
+        varType: list(string)
+        defaultValue: []
+      - name: serverless_neg_backends
+        description: The list of serverless backend which serves the traffic.
+        varType: |-
+          list(object({
+              region          = string
+              type            = string // cloud-run, cloud-function, and app-engine
+              service_name    = string
+              service_version = optional(string)
+              capacity_scaler = optional(number, 1.0)
+            }))
+        defaultValue: []
+      - name: groups
+        description: The list of backend instance group which serves the traffic.
+        varType: |-
+          list(object({
+              group       = string
+              description = optional(string)
+
+              balancing_mode               = optional(string)
+              capacity_scaler              = optional(number)
+              max_connections              = optional(number)
+              max_connections_per_instance = optional(number)
+              max_connections_per_endpoint = optional(number)
+              max_rate                     = optional(number)
+              max_rate_per_instance        = optional(number)
+              max_rate_per_endpoint        = optional(number)
+              max_utilization              = optional(number)
+            }))
+        defaultValue: []
+      - name: create_address
+        description: Create a new global IPv4 address
+        varType: bool
+        defaultValue: true
+      - name: labels
+        description: The labels to attach to resources created by this module
+        varType: map(string)
+        defaultValue: {}
+      - name: ssl
+        description: "Set to `true` to enable SSL support. If `true` then at least one of these are required: 1) `ssl_certificates` OR 2) `create_ssl_certificate` set to `true` and `private_key/certificate` OR  3) `managed_ssl_certificate_domains`, OR 4) `certificate_map`"
+        varType: bool
+        defaultValue: false
+      - name: create_ssl_certificate
+        description: If `true`, Create certificate using `private_key/certificate`
+        varType: bool
+        defaultValue: false
+      - name: private_key
+        description: Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true`
+        varType: string
+      - name: certificate
+        description: Content of the SSL certificate. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true`
+        varType: string
+      - name: ssl_certificates
+        description: SSL cert self_link list. Requires `ssl` to be set to `true`
+        varType: list(string)
+        defaultValue: []
+      - name: managed_ssl_certificate_domains
+        description: Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true`
+        varType: list(string)
+        defaultValue: []
+      - name: random_certificate_suffix
+        description: Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert.
+        varType: bool
+        defaultValue: false
+      - name: network
+        description: Network for INTERNAL_SELF_MANAGED load balancing scheme
+        varType: string
+        defaultValue: default
+      - name: http_port
+        description: The port for the HTTP load balancer
+        varType: number
+        defaultValue: 80
+      - name: https_port
+        description: The port for the HTTPS load balancer
+        varType: number
+        defaultValue: 443
+      - name: create_url_map
+        description: Set to `false` if url_map variable is provided.
+        varType: bool
+        defaultValue: true
+      - name: https_redirect
+        description: Set to `true` to enable https redirect on the lb.
+        varType: bool
+        defaultValue: false
+      - name: ssl_policy
+        description: Selfink to SSL Policy
+        varType: string
+      - name: server_tls_policy
+        description: The resource URL for the server TLS policy to associate with the https proxy service
+        varType: string
+      - name: http_keep_alive_timeout_sec
+        description: Specifies how long to keep a connection open, after completing a response, while there is no matching traffic (in seconds).
+        varType: number
+      - name: address
+        description: Existing IPv4 address to use (the actual IP address value)
+        varType: string
+      - name: http_forward
+        description: Set to `false` to disable HTTP port 80 forward
+        varType: bool
+        defaultValue: true
+      - name: url_map_input
+        description: List of host, path and backend service for creating url_map
+        varType: |-
+          list(object({
+              host            = string
+              path            = string
+              backend_service = string
+            }))
+        defaultValue: []
+      - name: url_map_resource_uri
+        description: The url_map resource to use. Default is to send all traffic to first backend.
+        varType: string
     outputs:
-      - name: backend_service_name
-        description: The name of the backend service
-      - name: forwarding_rule_ip
-        description: The IP address of the forwarding rule
-      - name: proxy_name
-        description: The name of the HTTP proxy
-      - name: url_map_name
-        description: The name of the URL map
+      - name: backend_services
+        description: The region backend service resources.
+      - name: external_ip
+        description: The external IPv4 assigned to the fowarding rule.
+      - name: http_proxy
+        description: The HTTP proxy used by this module.
+      - name: https_proxy
+        description: The HTTPS proxy used by this module.
+      - name: url_map
+        description: The default URL map used by this module.
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/compute.xpnAdmin
+      - level: Project
+        roles:
+          - roles/owner
+          - roles/storage.admin
+    services:
+      - cloudresourcemanager.googleapis.com
+      - storage-api.googleapis.com
+      - serviceusage.googleapis.com
+      - compute.googleapis.com
+      - run.googleapis.com
+      - iam.googleapis.com
+      - certificatemanager.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 6.0, < 7"
+      - source: hashicorp/google-beta
+        version: ">= 6.0, < 7"
+      - source: hashicorp/random
+        version: ">= 2.1"

--- a/modules/backend/README.md
+++ b/modules/backend/README.md
@@ -1,0 +1,37 @@
+# HTTP Regional Load balancer backend module
+This module creates `google_compute_region_backend_service` resource and its dependencies. This module can be used with `modules/frontend`. The separation of the modules makes it easier for creating backend and frontend resources independent of each other. The logical separation helps in improved maintainability.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| affinity\_cookie\_ttl\_sec | Lifetime of cookies in seconds if session\_affinity is GENERATED\_COOKIE. | `number` | `null` | no |
+| connection\_draining\_timeout\_sec | Time for which instance will be drained (not accept new connections, but still work to finish started). | `number` | `null` | no |
+| description | Description of the backend service. | `string` | `null` | no |
+| enable\_cdn | Enable Cloud CDN for this BackendService. | `bool` | `false` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| groups | The list of backend instance group which serves the traffic. | <pre>list(object({<br>    group       = string<br>    description = optional(string)<br><br>    balancing_mode               = optional(string)<br>    capacity_scaler              = optional(number, 1.0)<br>    max_connections              = optional(number)<br>    max_connections_per_instance = optional(number)<br>    max_connections_per_endpoint = optional(number)<br>    max_rate                     = optional(number)<br>    max_rate_per_instance        = optional(number)<br>    max_rate_per_endpoint        = optional(number)<br>    max_utilization              = optional(number)<br>  }))</pre> | `[]` | no |
+| health\_check | Input for creating HttpHealthCheck or HttpsHealthCheck resource for health checking this BackendService. A health check must be specified unless the backend service uses an internet or serverless NEG as a backend. | <pre>object({<br>    host                = optional(string, null)<br>    request_path        = optional(string, null)<br>    request             = optional(string, null)<br>    response            = optional(string, null)<br>    port                = optional(number, null)<br>    port_name           = optional(string, null)<br>    proxy_header        = optional(string, null)<br>    port_specification  = optional(string, null)<br>    protocol            = optional(string, null)<br>    check_interval_sec  = optional(number, 10)<br>    timeout_sec         = optional(number, 10)<br>    healthy_threshold   = optional(number, 2)<br>    unhealthy_threshold = optional(number, 2)<br>    logging             = optional(bool, true)<br>  })</pre> | `null` | no |
+| host\_path\_mappings | The list of host/path for which traffic should be sent to this backend service | <pre>list(object({<br>    host = string<br>    path = string<br>  }))</pre> | <pre>[<br>  {<br>    "host": "*",<br>    "path": "/*"<br>  }<br>]</pre> | no |
+| load\_balancing\_scheme | Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL\_MANAGED for Envoy-based load balancer, and INTERNAL\_SELF\_MANAGED for traffic director) | `string` | `"EXTERNAL_MANAGED"` | no |
+| locality\_lb\_policy | The load balancing algorithm used within the scope of the locality. | `string` | `null` | no |
+| name | Name for the load balancer backend service. | `string` | n/a | yes |
+| port\_name | Name of backend port. The same name should appear in the instance groups referenced by this service. Required when the load balancing scheme is EXTERNAL. | `string` | `"http"` | no |
+| project\_id | The project to deploy load balancer backend resources. | `string` | n/a | yes |
+| protocol | The protocol this BackendService uses to communicate with backends. | `string` | `"HTTP"` | no |
+| region | The region where the load balancer backend service will be created | `string` | n/a | yes |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| serverless\_neg\_backends | The list of serverless backends which serves the traffic. A region can have only one serverless backend. | <pre>list(object({<br>    region          = string<br>    type            = string // cloud-run, cloud-function, and app-engine<br>    service_name    = string<br>    service_version = optional(string)<br>    capacity_scaler = optional(number, 1.0)<br>  }))</pre> | `[]` | no |
+| session\_affinity | Type of session affinity to use. Possible values are: NONE, CLIENT\_IP, CLIENT\_IP\_PORT\_PROTO, CLIENT\_IP\_PROTO, GENERATED\_COOKIE, HEADER\_FIELD, HTTP\_COOKIE, STRONG\_COOKIE\_AFFINITY. | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| timeout\_sec | This has different meaning for different type of load balancing. Please refer https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| backend\_service\_info | Host, path and backend service mapping |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/backend/metadata.display.yaml
+++ b/modules/backend/metadata.display.yaml
@@ -15,42 +15,25 @@
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
-  name: terraform-google-regional-lb-http-display
+  name: terraform-google-regional-lb-http-backend-display
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
-    title: Regional HTTP Load Balancer Terraform Module
+    title: HTTP Regional Load balancer backend module
     source:
       repo: https://github.com/googlestaging/terraform-google-regional-lb-http.git
       sourceType: git
+      dir: /modules/backend
   ui:
     input:
       variables:
-        address:
-          name: address
-          title: Address
         affinity_cookie_ttl_sec:
           name: affinity_cookie_ttl_sec
           title: Affinity Cookie Ttl Sec
-        backend_service_name:
-          name: backend_service_name
-          title: Backend Service Name
-        certificate:
-          name: certificate
-          title: Certificate
         connection_draining_timeout_sec:
           name: connection_draining_timeout_sec
           title: Connection Draining Timeout Sec
-        create_address:
-          name: create_address
-          title: Create Address
-        create_ssl_certificate:
-          name: create_ssl_certificate
-          title: Create Ssl Certificate
-        create_url_map:
-          name: create_url_map
-          title: Create Url Map
         description:
           name: description
           title: Description
@@ -63,90 +46,46 @@ spec:
         firewall_projects:
           name: firewall_projects
           title: Firewall Projects
-        forwarding_rule_name:
-          name: forwarding_rule_name
-          title: Forwarding Rule Name
         groups:
           name: groups
           title: Groups
         health_check:
           name: health_check
           title: Health Check
-        http_forward:
-          name: http_forward
-          title: Http Forward
-        http_keep_alive_timeout_sec:
-          name: http_keep_alive_timeout_sec
-          title: Http Keep Alive Timeout Sec
-        http_port:
-          name: http_port
-          title: Http Port
-        https_port:
-          name: https_port
-          title: Https Port
-        https_redirect:
-          name: https_redirect
-          title: Https Redirect
-        labels:
-          name: labels
-          title: Labels
+        host_path_mappings:
+          name: host_path_mappings
+          title: Host Path Mappings
+          level: 1
         load_balancing_scheme:
           name: load_balancing_scheme
           title: Load Balancing Scheme
         locality_lb_policy:
           name: locality_lb_policy
           title: Locality Lb Policy
-        managed_ssl_certificate_domains:
-          name: managed_ssl_certificate_domains
-          title: Managed Ssl Certificate Domains
         name:
           name: name
           title: Name
-        network:
-          name: network
-          title: Network
         port_name:
           name: port_name
           title: Port Name
-        private_key:
-          name: private_key
-          title: Private Key
         project_id:
           name: project_id
           title: Project Id
         protocol:
           name: protocol
           title: Protocol
-        proxy_name:
-          name: proxy_name
-          title: Proxy Name
-        random_certificate_suffix:
-          name: random_certificate_suffix
-          title: Random Certificate Suffix
         region:
           name: region
           title: Region
         security_policy:
           name: security_policy
           title: Security Policy
-        server_tls_policy:
-          name: server_tls_policy
-          title: Server Tls Policy
         serverless_neg_backends:
           name: serverless_neg_backends
           title: Serverless Neg Backends
         session_affinity:
           name: session_affinity
           title: Session Affinity
-        ssl:
-          name: ssl
-          title: Ssl
-        ssl_certificates:
-          name: ssl_certificates
-          title: Ssl Certificates
-        ssl_policy:
-          name: ssl_policy
-          title: Ssl Policy
         target_service_accounts:
           name: target_service_accounts
           title: Target Service Accounts
@@ -156,15 +95,3 @@ spec:
         timeout_sec:
           name: timeout_sec
           title: Timeout Sec
-        url_map:
-          name: url_map
-          title: Url Map
-        url_map_input:
-          name: url_map_input
-          title: Url Map Input
-        url_map_name:
-          name: url_map_name
-          title: Url Map Name
-        url_map_resource_uri:
-          name: url_map_resource_uri
-          title: Url Map Resource Uri

--- a/modules/backend/metadata.yaml
+++ b/modules/backend/metadata.yaml
@@ -1,0 +1,208 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-regional-lb-http-backend
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: HTTP Regional Load balancer backend module
+    source:
+      repo: https://github.com/googlestaging/terraform-google-regional-lb-http.git
+      sourceType: git
+      dir: /modules/backend
+    version: 0.0.1
+    actuationTool:
+      flavor: Terraform
+      version: ">= 1.3"
+    description: {}
+  content:
+    examples:
+      - name: cloud-run
+        location: examples/cloud-run
+  interfaces:
+    variables:
+      - name: project_id
+        description: The project to deploy load balancer backend resources.
+        varType: string
+        required: true
+      - name: region
+        description: The region where the load balancer backend service will be created
+        varType: string
+        required: true
+      - name: name
+        description: Name for the load balancer backend service.
+        varType: string
+        required: true
+      - name: host_path_mappings
+        description: The list of host/path for which traffic should be sent to this backend service
+        varType: |-
+          list(object({
+              host = string
+              path = string
+            }))
+        defaultValue:
+          - host: "*"
+            path: /*
+      - name: serverless_neg_backends
+        description: The list of serverless backends which serves the traffic. A region can have only one serverless backend.
+        varType: |-
+          list(object({
+              region          = string
+              type            = string // cloud-run, cloud-function, and app-engine
+              service_name    = string
+              service_version = optional(string)
+              capacity_scaler = optional(number, 1.0)
+            }))
+        defaultValue: []
+        connections:
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-cloud-run//modules/v2
+              version: ">= 0.13"
+            spec:
+              outputExpr: "{\"region\": location, \"service_name\": service_name, \"type\": \"cloud-run\", \"service_version\": \"\", \"capacity_scaler\": 1.0}"
+      - name: groups
+        description: The list of backend instance group which serves the traffic.
+        varType: |-
+          list(object({
+              group       = string
+              description = optional(string)
+
+              balancing_mode               = optional(string)
+              capacity_scaler              = optional(number, 1.0)
+              max_connections              = optional(number)
+              max_connections_per_instance = optional(number)
+              max_connections_per_endpoint = optional(number)
+              max_rate                     = optional(number)
+              max_rate_per_instance        = optional(number)
+              max_rate_per_endpoint        = optional(number)
+              max_utilization              = optional(number)
+            }))
+        defaultValue: []
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-vm//modules/mig
+              version: ">= 12.0"
+            spec:
+              outputExpr: "{\"group\": instance_group, \"description\": \"Input created by connection\", \"balancing_mode\": \"UTILIZATION\", \"capacity_scaler\": 1.0, \"max_connections\": 1000, \"max_connections_per_instance\": 1000, \"max_connections_per_endpoint\": 1000, \"max_rate\": 1000, \"max_rate_per_instance\": 100, \"max_rate_per_endpoint\": 100, \"max_utilization\": 0.8}"
+      - name: load_balancing_scheme
+        description: Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL_MANAGED for Envoy-based load balancer, and INTERNAL_SELF_MANAGED for traffic director)
+        varType: string
+        defaultValue: EXTERNAL_MANAGED
+      - name: protocol
+        description: The protocol this BackendService uses to communicate with backends.
+        varType: string
+        defaultValue: HTTP
+      - name: port_name
+        description: Name of backend port. The same name should appear in the instance groups referenced by this service. Required when the load balancing scheme is EXTERNAL.
+        varType: string
+        defaultValue: http
+      - name: description
+        description: Description of the backend service.
+        varType: string
+      - name: health_check
+        description: Input for creating HttpHealthCheck or HttpsHealthCheck resource for health checking this BackendService. A health check must be specified unless the backend service uses an internet or serverless NEG as a backend.
+        varType: |-
+          object({
+              host                = optional(string, null)
+              request_path        = optional(string, null)
+              request             = optional(string, null)
+              response            = optional(string, null)
+              port                = optional(number, null)
+              port_name           = optional(string, null)
+              proxy_header        = optional(string, null)
+              port_specification  = optional(string, null)
+              protocol            = optional(string, null)
+              check_interval_sec  = optional(number, 10)
+              timeout_sec         = optional(number, 10)
+              healthy_threshold   = optional(number, 2)
+              unhealthy_threshold = optional(number, 2)
+              logging             = optional(bool, true)
+            })
+      - name: firewall_networks
+        description: Names of the networks to create firewall rules in
+        varType: list(string)
+        defaultValue:
+          - default
+      - name: firewall_projects
+        description: Names of the projects to create firewall rules in
+        varType: list(string)
+        defaultValue:
+          - default
+      - name: target_tags
+        description: List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified.
+        varType: list(string)
+        defaultValue: []
+      - name: target_service_accounts
+        description: List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified.
+        varType: list(string)
+        defaultValue: []
+      - name: connection_draining_timeout_sec
+        description: Time for which instance will be drained (not accept new connections, but still work to finish started).
+        varType: number
+      - name: enable_cdn
+        description: Enable Cloud CDN for this BackendService.
+        varType: bool
+        defaultValue: false
+      - name: session_affinity
+        description: "Type of session affinity to use. Possible values are: NONE, CLIENT_IP, CLIENT_IP_PORT_PROTO, CLIENT_IP_PROTO, GENERATED_COOKIE, HEADER_FIELD, HTTP_COOKIE, STRONG_COOKIE_AFFINITY."
+        varType: string
+      - name: affinity_cookie_ttl_sec
+        description: Lifetime of cookies in seconds if session_affinity is GENERATED_COOKIE.
+        varType: number
+      - name: locality_lb_policy
+        description: The load balancing algorithm used within the scope of the locality.
+        varType: string
+      - name: security_policy
+        description: The resource URL for the security policy to associate with the backend service
+        varType: string
+      - name: timeout_sec
+        description: This has different meaning for different type of load balancing. Please refer https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+        varType: number
+    outputs:
+      - name: backend_service_info
+        description: Host, path and backend service mapping
+        type:
+          - list
+          - - object
+            - backend_service: string
+              host: string
+              path: string
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/compute.xpnAdmin
+      - level: Project
+        roles:
+          - roles/owner
+          - roles/storage.admin
+    services:
+      - cloudresourcemanager.googleapis.com
+      - storage-api.googleapis.com
+      - serviceusage.googleapis.com
+      - compute.googleapis.com
+      - run.googleapis.com
+      - iam.googleapis.com
+      - certificatemanager.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 6.0, < 7"
+      - source: hashicorp/google-beta
+        version: ">= 6.0, < 7"
+      - source: hashicorp/random
+        version: ">= 2.1"

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -14,19 +14,59 @@
  * limitations under the License.
  */
 
-variable "name" {
-  description = "Name for the backend service."
-  type        = string
-}
-
 variable "project_id" {
-  description = "The project to deploy to, if not set the default provider project is used."
+  description = "The project to deploy load balancer backend resources."
   type        = string
 }
 
 variable "region" {
   description = "The region where the load balancer backend service will be created"
   type        = string
+}
+
+variable "name" {
+  description = "Name for the load balancer backend service."
+  type        = string
+}
+
+variable "host_path_mappings" {
+  description = "The list of host/path for which traffic should be sent to this backend service"
+  type = list(object({
+    host = string
+    path = string
+  }))
+  default = [{ host : "*", path : "/*" }]
+}
+
+variable "serverless_neg_backends" {
+  description = "The list of serverless backends which serves the traffic. A region can have only one serverless backend."
+  type = list(object({
+    region          = string
+    type            = string // cloud-run, cloud-function, and app-engine
+    service_name    = string
+    service_version = optional(string)
+    capacity_scaler = optional(number, 1.0)
+  }))
+  default = []
+}
+
+variable "groups" {
+  description = "The list of backend instance group which serves the traffic."
+  type = list(object({
+    group       = string
+    description = optional(string)
+
+    balancing_mode               = optional(string)
+    capacity_scaler              = optional(number, 1.0)
+    max_connections              = optional(number)
+    max_connections_per_instance = optional(number)
+    max_connections_per_endpoint = optional(number)
+    max_rate                     = optional(number)
+    max_rate_per_instance        = optional(number)
+    max_rate_per_endpoint        = optional(number)
+    max_utilization              = optional(number)
+  }))
+  default = []
 }
 
 variable "load_balancing_scheme" {
@@ -50,48 +90,6 @@ variable "port_name" {
 variable "description" {
   description = "Description of the backend service."
   type        = string
-  default     = null
-}
-
-variable "connection_draining_timeout_sec" {
-  description = "Time for which instance will be drained (not accept new connections, but still work to finish started)."
-  type        = number
-  default     = null
-}
-
-variable "enable_cdn" {
-  description = "Enable Cloud CDN for this BackendService."
-  type        = bool
-  default     = false
-}
-
-variable "session_affinity" {
-  description = "Type of session affinity to use. Possible values are: NONE, CLIENT_IP, CLIENT_IP_PORT_PROTO, CLIENT_IP_PROTO, GENERATED_COOKIE, HEADER_FIELD, HTTP_COOKIE, STRONG_COOKIE_AFFINITY."
-  type        = string
-  default     = null
-}
-
-variable "affinity_cookie_ttl_sec" {
-  description = "Lifetime of cookies in seconds if session_affinity is GENERATED_COOKIE."
-  type        = number
-  default     = null
-}
-
-variable "locality_lb_policy" {
-  description = "The load balancing algorithm used within the scope of the locality."
-  type        = string
-  default     = null
-}
-
-variable "security_policy" {
-  description = "The resource URL for the security policy to associate with the backend service"
-  type        = string
-  default     = null
-}
-
-variable "timeout_sec" {
-  description = "This has different meaning for different type of load balancing. Please refer https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting"
-  type        = number
   default     = null
 }
 
@@ -140,42 +138,44 @@ variable "target_service_accounts" {
   default     = []
 }
 
-variable "serverless_neg_backends" {
-  description = "The list of serverless backend which serves the traffic."
-  type = list(object({
-    region          = string
-    type            = string // cloud-run, cloud-function, and app-engine
-    service_name    = string
-    service_version = optional(string)
-    capacity_scaler = optional(number, 1.0)
-  }))
-  default = []
+variable "connection_draining_timeout_sec" {
+  description = "Time for which instance will be drained (not accept new connections, but still work to finish started)."
+  type        = number
+  default     = null
 }
 
-variable "groups" {
-  description = "The list of backend instance group which serves the traffic."
-  type = list(object({
-    group       = string
-    description = optional(string)
-
-    balancing_mode               = optional(string)
-    capacity_scaler              = optional(number)
-    max_connections              = optional(number)
-    max_connections_per_instance = optional(number)
-    max_connections_per_endpoint = optional(number)
-    max_rate                     = optional(number)
-    max_rate_per_instance        = optional(number)
-    max_rate_per_endpoint        = optional(number)
-    max_utilization              = optional(number)
-  }))
-  default = []
+variable "enable_cdn" {
+  description = "Enable Cloud CDN for this BackendService."
+  type        = bool
+  default     = false
 }
 
-variable "host_path_mappings" {
-  description = "The list of host/path for which traffic could be sent to the backend service"
-  type = list(object({
-    host = string
-    path = string
-  }))
-  default = [{ host : "*", path : "/*" }]
+variable "session_affinity" {
+  description = "Type of session affinity to use. Possible values are: NONE, CLIENT_IP, CLIENT_IP_PORT_PROTO, CLIENT_IP_PROTO, GENERATED_COOKIE, HEADER_FIELD, HTTP_COOKIE, STRONG_COOKIE_AFFINITY."
+  type        = string
+  default     = null
+}
+
+variable "affinity_cookie_ttl_sec" {
+  description = "Lifetime of cookies in seconds if session_affinity is GENERATED_COOKIE."
+  type        = number
+  default     = null
+}
+
+variable "locality_lb_policy" {
+  description = "The load balancing algorithm used within the scope of the locality."
+  type        = string
+  default     = null
+}
+
+variable "security_policy" {
+  description = "The resource URL for the security policy to associate with the backend service"
+  type        = string
+  default     = null
+}
+
+variable "timeout_sec" {
+  description = "This has different meaning for different type of load balancing. Please refer https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting"
+  type        = number
+  default     = null
 }

--- a/modules/frontend/README.md
+++ b/modules/frontend/README.md
@@ -1,0 +1,45 @@
+# HTTP Regional Load balancer frontend module
+This module creates `HTTP(S) forwarding rule` and its dependencies. This modules doesn't create `google_compute_region_backend_service` which can be created by using `modules/frontend`. The separation of the modules makes it easier for creating backend and frontend resources independent of each other. The logical separation helps in improved maintainability.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| certificate | Content of the SSL certificate. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ssl\_certificate | If `true`, Create certificate using `private_key/certificate` | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map\_resource\_uri variable is provided. | `bool` | `true` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| http\_keep\_alive\_timeout\_sec | Specifies how long to keep a connection open, after completing a response, while there is no matching traffic (in seconds). | `number` | `null` | no |
+| http\_port | The port for the HTTP load balancer | `number` | `80` | no |
+| https\_port | The port for the HTTPS load balancer | `number` | `443` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
+| load\_balancing\_scheme | Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL\_MANAGED for Envoy-based load balancer, and INTERNAL\_SELF\_MANAGED for traffic director) | `string` | `"EXTERNAL_MANAGED"` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| network | VPC network for the forwarding rule. It should not be default | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
+| project\_id | The project to deploy load balancer frontend resources.. | `string` | n/a | yes |
+| proxy\_only\_subnet\_ip | ip\_cidr\_range for creating proxy\_only subnetwork in the provided VPC network. | `string` | `"10.129.0.0/23"` | no |
+| random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
+| region | The region where the load balancer will be created | `string` | n/a | yes |
+| server\_tls\_policy | The resource URL for the server TLS policy to associate with the https proxy service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support. If `true` then at least one of these are required: 1) `ssl_certificates` OR 2) `create_ssl_certificate` set to `true` and `private_key/certificate` OR  3) `managed_ssl_certificate_domains`, OR 4) `certificate_map` | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| url\_map\_input | List of host, path and backend service for creating url\_map when create\_url\_map is set to true. | <pre>list(object({<br>    host            = string<br>    path            = string<br>    backend_service = string<br>  }))</pre> | `[]` | no |
+| url\_map\_resource\_uri | The url\_map resource to use. This is the resource uri of the url map created out of band. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external\_ip | The external IPv4 assigned to the fowarding rule. |
+| http\_proxy | The HTTP proxy used by this module. |
+| https\_proxy | The HTTPS proxy used by this module. |
+| ssl\_certificate\_created | The SSL certificate create from key/pem |
+| url\_map | The URL map used by this load balancer frontend. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/frontend/metadata.display.yaml
+++ b/modules/frontend/metadata.display.yaml
@@ -15,33 +15,25 @@
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
-  name: terraform-google-regional-lb-http-display
+  name: terraform-google-regional-lb-http-frontend-display
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
-    title: Regional HTTP Load Balancer Terraform Module
+    title: HTTP Regional Load balancer frontend module
     source:
       repo: https://github.com/googlestaging/terraform-google-regional-lb-http.git
       sourceType: git
+      dir: /modules/frontend
   ui:
     input:
       variables:
         address:
           name: address
           title: Address
-        affinity_cookie_ttl_sec:
-          name: affinity_cookie_ttl_sec
-          title: Affinity Cookie Ttl Sec
-        backend_service_name:
-          name: backend_service_name
-          title: Backend Service Name
         certificate:
           name: certificate
           title: Certificate
-        connection_draining_timeout_sec:
-          name: connection_draining_timeout_sec
-          title: Connection Draining Timeout Sec
         create_address:
           name: create_address
           title: Create Address
@@ -51,27 +43,6 @@ spec:
         create_url_map:
           name: create_url_map
           title: Create Url Map
-        description:
-          name: description
-          title: Description
-        enable_cdn:
-          name: enable_cdn
-          title: Enable Cdn
-        firewall_networks:
-          name: firewall_networks
-          title: Firewall Networks
-        firewall_projects:
-          name: firewall_projects
-          title: Firewall Projects
-        forwarding_rule_name:
-          name: forwarding_rule_name
-          title: Forwarding Rule Name
-        groups:
-          name: groups
-          title: Groups
-        health_check:
-          name: health_check
-          title: Health Check
         http_forward:
           name: http_forward
           title: Http Forward
@@ -93,9 +64,6 @@ spec:
         load_balancing_scheme:
           name: load_balancing_scheme
           title: Load Balancing Scheme
-        locality_lb_policy:
-          name: locality_lb_policy
-          title: Locality Lb Policy
         managed_ssl_certificate_domains:
           name: managed_ssl_certificate_domains
           title: Managed Ssl Certificate Domains
@@ -105,39 +73,25 @@ spec:
         network:
           name: network
           title: Network
-        port_name:
-          name: port_name
-          title: Port Name
         private_key:
           name: private_key
           title: Private Key
         project_id:
           name: project_id
           title: Project Id
-        protocol:
-          name: protocol
-          title: Protocol
-        proxy_name:
-          name: proxy_name
-          title: Proxy Name
+        proxy_only_subnet_ip:
+          name: proxy_only_subnet_ip
+          title: Proxy Only Subnet Ip
+          level: 1
         random_certificate_suffix:
           name: random_certificate_suffix
           title: Random Certificate Suffix
         region:
           name: region
           title: Region
-        security_policy:
-          name: security_policy
-          title: Security Policy
         server_tls_policy:
           name: server_tls_policy
           title: Server Tls Policy
-        serverless_neg_backends:
-          name: serverless_neg_backends
-          title: Serverless Neg Backends
-        session_affinity:
-          name: session_affinity
-          title: Session Affinity
         ssl:
           name: ssl
           title: Ssl
@@ -147,24 +101,13 @@ spec:
         ssl_policy:
           name: ssl_policy
           title: Ssl Policy
-        target_service_accounts:
-          name: target_service_accounts
-          title: Target Service Accounts
-        target_tags:
-          name: target_tags
-          title: Target Tags
-        timeout_sec:
-          name: timeout_sec
-          title: Timeout Sec
-        url_map:
-          name: url_map
-          title: Url Map
         url_map_input:
           name: url_map_input
           title: Url Map Input
-        url_map_name:
-          name: url_map_name
-          title: Url Map Name
         url_map_resource_uri:
           name: url_map_resource_uri
           title: Url Map Resource Uri
+    runtime:
+      outputs:
+        external_ip:
+          visibility: VISIBILITY_ROOT

--- a/modules/frontend/metadata.yaml
+++ b/modules/frontend/metadata.yaml
@@ -1,0 +1,186 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-regional-lb-http-frontend
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: HTTP Regional Load balancer frontend module
+    source:
+      repo: https://github.com/googlestaging/terraform-google-regional-lb-http.git
+      sourceType: git
+      dir: /modules/frontend
+    version: 0.0.1
+    actuationTool:
+      flavor: Terraform
+      version: ">= 1.3"
+    description: {}
+  content:
+    examples:
+      - name: cloud-run
+        location: examples/cloud-run
+  interfaces:
+    variables:
+      - name: project_id
+        description: The project to deploy load balancer frontend resources..
+        varType: string
+        required: true
+      - name: region
+        description: The region where the load balancer will be created
+        varType: string
+        required: true
+      - name: name
+        description: Name for the forwarding rule and prefix for supporting resources
+        varType: string
+        required: true
+      - name: network
+        description: VPC network for the forwarding rule. It should not be default
+        varType: string
+        required: true
+      - name: proxy_only_subnet_ip
+        description: ip_cidr_range for creating proxy_only subnetwork in the provided VPC network.
+        varType: string
+        defaultValue: 10.129.0.0/23
+      - name: load_balancing_scheme
+        description: Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL_MANAGED for Envoy-based load balancer, and INTERNAL_SELF_MANAGED for traffic director)
+        varType: string
+        defaultValue: EXTERNAL_MANAGED
+      - name: create_url_map
+        description: Set to `false` if url_map_resource_uri variable is provided.
+        varType: bool
+        defaultValue: true
+      - name: url_map_input
+        description: List of host, path and backend service for creating url_map when create_url_map is set to true.
+        varType: |-
+          list(object({
+              host            = string
+              path            = string
+              backend_service = string
+            }))
+        defaultValue: []
+        connections:
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-regional-lb-http//modules/backend
+              version: ">= 0.0.1"
+            spec:
+              outputExpr: backend_service_info
+      - name: url_map_resource_uri
+        description: The url_map resource to use. This is the resource uri of the url map created out of band.
+        varType: string
+      - name: create_address
+        description: Create a new global IPv4 address
+        varType: bool
+        defaultValue: true
+      - name: address
+        description: Existing IPv4 address to use (the actual IP address value)
+        varType: string
+      - name: labels
+        description: The labels to attach to resources created by this module
+        varType: map(string)
+        defaultValue: {}
+      - name: ssl
+        description: "Set to `true` to enable SSL support. If `true` then at least one of these are required: 1) `ssl_certificates` OR 2) `create_ssl_certificate` set to `true` and `private_key/certificate` OR  3) `managed_ssl_certificate_domains`, OR 4) `certificate_map`"
+        varType: bool
+        defaultValue: false
+      - name: create_ssl_certificate
+        description: If `true`, Create certificate using `private_key/certificate`
+        varType: bool
+        defaultValue: false
+      - name: private_key
+        description: Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true`
+        varType: string
+      - name: certificate
+        description: Content of the SSL certificate. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true`
+        varType: string
+      - name: ssl_certificates
+        description: SSL cert self_link list. Requires `ssl` to be set to `true`
+        varType: list(string)
+        defaultValue: []
+      - name: managed_ssl_certificate_domains
+        description: Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true`
+        varType: list(string)
+        defaultValue: []
+      - name: random_certificate_suffix
+        description: Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert.
+        varType: bool
+        defaultValue: false
+      - name: http_port
+        description: The port for the HTTP load balancer
+        varType: number
+        defaultValue: 80
+      - name: https_port
+        description: The port for the HTTPS load balancer
+        varType: number
+        defaultValue: 443
+      - name: https_redirect
+        description: Set to `true` to enable https redirect on the lb.
+        varType: bool
+        defaultValue: false
+      - name: http_forward
+        description: Set to `false` to disable HTTP port 80 forward
+        varType: bool
+        defaultValue: true
+      - name: ssl_policy
+        description: Selfink to SSL Policy
+        varType: string
+      - name: server_tls_policy
+        description: The resource URL for the server TLS policy to associate with the https proxy service
+        varType: string
+      - name: http_keep_alive_timeout_sec
+        description: Specifies how long to keep a connection open, after completing a response, while there is no matching traffic (in seconds).
+        varType: number
+    outputs:
+      - name: external_ip
+        description: The external IPv4 assigned to the fowarding rule.
+        type: string
+      - name: http_proxy
+        description: The HTTP proxy used by this module.
+        type: string
+      - name: https_proxy
+        description: The HTTPS proxy used by this module.
+        type: string
+      - name: ssl_certificate_created
+        description: The SSL certificate create from key/pem
+        type: string
+      - name: url_map
+        description: The URL map used by this load balancer frontend.
+        type: string
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/compute.xpnAdmin
+      - level: Project
+        roles:
+          - roles/owner
+          - roles/storage.admin
+    services:
+      - cloudresourcemanager.googleapis.com
+      - storage-api.googleapis.com
+      - serviceusage.googleapis.com
+      - compute.googleapis.com
+      - run.googleapis.com
+      - iam.googleapis.com
+      - certificatemanager.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 6.0, < 7"
+      - source: hashicorp/google-beta
+        version: ">= 6.0, < 7"
+      - source: hashicorp/random
+        version: ">= 2.1"

--- a/modules/frontend/outputs.tf
+++ b/modules/frontend/outputs.tf
@@ -31,8 +31,8 @@ output "https_proxy" {
 }
 
 output "url_map" {
-  description = "The default URL map used by this module."
-  value       = google_compute_region_url_map.default[*].self_link
+  description = "The URL map used by this load balancer frontend."
+  value       = local.url_map
 }
 
 output "ssl_certificate_created" {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -14,20 +14,58 @@
  * limitations under the License.
  */
 
-variable "name" {
-  description = "Name for the forwarding rule and prefix for supporting resources"
-  type        = string
-}
-
 variable "project_id" {
-  description = "The project to deploy to, if not set the default provider project is used."
+  description = "The project to deploy load balancer frontend resources.."
   type        = string
 }
 
 variable "region" {
   description = "The region where the load balancer will be created"
   type        = string
-  default     = "us-central1"
+}
+
+variable "name" {
+  description = "Name for the forwarding rule and prefix for supporting resources"
+  type        = string
+}
+
+variable "network" {
+  description = "VPC network for the forwarding rule. It should not be default"
+  type        = string
+}
+
+variable "proxy_only_subnet_ip" {
+  description = "ip_cidr_range for creating proxy_only subnetwork in the provided VPC network."
+  type        = string
+  default     = "10.129.0.0/23"
+}
+
+variable "load_balancing_scheme" {
+  description = "Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL_MANAGED for Envoy-based load balancer, and INTERNAL_SELF_MANAGED for traffic director)"
+  type        = string
+  default     = "EXTERNAL_MANAGED"
+}
+
+variable "create_url_map" {
+  description = "Set to `false` if url_map_resource_uri variable is provided."
+  type        = bool
+  default     = true
+}
+
+variable "url_map_input" {
+  description = "List of host, path and backend service for creating url_map when create_url_map is set to true."
+  type = list(object({
+    host            = string
+    path            = string
+    backend_service = string
+  }))
+  default = []
+}
+
+variable "url_map_resource_uri" {
+  description = "The url_map resource to use. This is the resource uri of the url map created out of band."
+  type        = string
+  default     = null
 }
 
 variable "create_address" {
@@ -46,12 +84,6 @@ variable "labels" {
   description = "The labels to attach to resources created by this module"
   type        = map(string)
   default     = {}
-}
-
-variable "load_balancing_scheme" {
-  description = "Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL_MANAGED for Envoy-based load balancer, and INTERNAL_SELF_MANAGED for traffic director)"
-  type        = string
-  default     = "EXTERNAL_MANAGED"
 }
 
 variable "ssl" {
@@ -96,22 +128,6 @@ variable "random_certificate_suffix" {
   default     = false
 }
 
-variable "url_map_input" {
-  description = "List of host, path and backend service for creating url_map"
-  type = list(object({
-    host            = string
-    path            = string
-    backend_service = string
-  }))
-  default = []
-}
-
-variable "network" {
-  description = "Network for INTERNAL_SELF_MANAGED load balancing scheme"
-  type        = string
-  default     = "default"
-}
-
 variable "http_port" {
   description = "The port for the HTTP load balancer"
   type        = number
@@ -130,18 +146,6 @@ variable "https_port" {
     condition     = var.https_port >= 1 && var.https_port <= 65535
     error_message = "You must specify exactly one port between 1 and 65535"
   }
-}
-
-variable "create_url_map" {
-  description = "Set to `false` if url_map variable is provided."
-  type        = bool
-  default     = true
-}
-
-variable "url_map_resource_uri" {
-  description = "The url_map resource to use. Default is to send all traffic to first backend."
-  type        = string
-  default     = null
 }
 
 variable "https_redirect" {
@@ -171,11 +175,5 @@ variable "server_tls_policy" {
 variable "http_keep_alive_timeout_sec" {
   description = "Specifies how long to keep a connection open, after completing a response, while there is no matching traffic (in seconds)."
   type        = number
-  default     = null
-}
-
-variable "proxy_subnetwork" {
-  description = "subnetwork for the proxy."
-  type        = string
   default     = null
 }


### PR DESCRIPTION
This PR makes below changes,

* Adds proxy-only subnetwork creation in `modules/frontend`
* Adds build file for cloudbuild
* Adds readme and generates metadata and display metadata files
* Adds connection metadata
* Adds output type
* Reorders the input variables for modules/frontend and modules/backend
