### PR TITLE
feat: allow using certificate manager certificates

### DIFF
--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -123,6 +123,9 @@ spec:
         random_certificate_suffix:
           name: random_certificate_suffix
           title: Random Certificate Suffix
+        certificate_manager_certificates:
+          name: certificate_manager_certificates
+          title: Certificate Manager Certificates
         region:
           name: region
           title: Region

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -199,6 +199,10 @@ spec:
         description: Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert.
         varType: bool
         defaultValue: false
+      - name: certificate_manager_certificates
+        description: Certificate Manager cert self_link list. Requires `ssl` to be set to `true`
+        varType: list(string)
+        defaultValue: null
       - name: network
         description: Network for INTERNAL_SELF_MANAGED load balancing scheme
         varType: string

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -37,6 +37,8 @@ locals {
   first_host            = try(keys(local.backend_services_by_host)[0], null)
   first_path            = try(keys(local.backend_services_by_host[local.first_host])[0], null)
   first_backend_service = try(local.backend_services_by_host[local.first_host][local.first_path], null)
+
+  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
 }
 
 ### Proxy only subnetwork ###
@@ -186,15 +188,16 @@ resource "google_compute_region_target_http_proxy" "default" {
 
 # HTTPS proxy when ssl is true
 resource "google_compute_region_target_https_proxy" "default" {
-  project                     = var.project_id
-  count                       = var.ssl ? 1 : 0
-  name                        = "${var.name}-regional-https-proxy"
-  region                      = var.region
-  url_map                     = local.url_map
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  ssl_policy                  = var.ssl_policy
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  project                          = var.project_id
+  count                            = var.ssl ? 1 : 0
+  name                             = "${var.name}-regional-https-proxy"
+  region                           = var.region
+  url_map                          = local.url_map
+  ssl_certificates                 = length(local.ssl_certificates) > 0 ? local.ssl_certificates : null
+  certificate_manager_certificates = var.certificate_manager_certificates
+  ssl_policy                       = var.ssl_policy
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -158,6 +158,12 @@ variable "random_certificate_suffix" {
   default     = false
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager cert self_link list. Requires `ssl` to be set to `true`"
+  type        = list(string)
+  default     = null
+}
+
 variable "http_port" {
   description = "The port for the HTTP load balancer"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -225,6 +225,12 @@ variable "random_certificate_suffix" {
   default     = false
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager cert self_link list. Requires `ssl` to be set to `true`"
+  type        = list(string)
+  default     = null
+}
+
 variable "network" {
   description = "Network for INTERNAL_SELF_MANAGED load balancing scheme"
   type        = string


### PR DESCRIPTION
Somewhat fixes https://github.com/GoogleCloudPlatform/terraform-google-regional-lb-http/issues/38 because Certificate Manager seems to be the only way to use certificates with regional load balancers