### PR TITLE
feat: Add forwarding_rule output

### DIFF
--- a/modules/frontend/README.md
+++ b/modules/frontend/README.md
@@ -43,6 +43,7 @@ This module creates `HTTP(S) forwarding rule` and its dependencies. This modules
 |------|-------------|
 | apphub\_service\_uri | A list of all App Hub service URIs, including HTTP, HTTPS, and IPv6 versions. |
 | external\_ip | The external IPv4 assigned to the fowarding rule. |
+| forwarding\_rule | The provisioned forwarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
 | ip\_address\_http | The internal/external IP address assigned to the HTTP forwarding rule. |

--- a/modules/frontend/metadata.display.yaml
+++ b/modules/frontend/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/frontend/metadata.yaml
+++ b/modules/frontend/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -189,6 +189,9 @@ spec:
               service_uri: string
       - name: external_ip
         description: The external IPv4 assigned to the fowarding rule.
+        type: string
+      - name: forwarding_rule
+        description: The provisioned forwarding rule.
         type: string
       - name: http_proxy
         description: The HTTP proxy used by this module.

--- a/modules/frontend/outputs.tf
+++ b/modules/frontend/outputs.tf
@@ -30,6 +30,11 @@ output "ip_address_https" {
   value       = try(google_compute_forwarding_rule.https[0].ip_address, "")
 }
 
+output "forwarding_rule" {
+  description = "The provisioned forwarding rule."
+  value       = try(google_compute_forwarding_rule.default[0].self_link, google_compute_forwarding_rule.https[0].self_link, "")
+}
+
 output "http_proxy" {
   description = "The HTTP proxy used by this module."
   value       = google_compute_region_target_http_proxy.default[*].self_link


### PR DESCRIPTION
Adding the output for connection with the PSC service attachment target service.
Testing:
https://screenshot.googleplex.com/68YmVRLES5MaRFb
https://screenshot.googleplex.com/4tuAzaQnvAVFcFa