### PR TITLE
feat: Add missing VPC connection for Regional LB Frontend

### DIFF
--- a/examples/backend-services-with-iap/main.tf
+++ b/examples/backend-services-with-iap/main.tf
@@ -16,7 +16,7 @@
 
 module "lb-backend-iap" {
   source  = "GoogleCloudPlatform/regional-lb-http/google//modules/backend"
-  version = "~> 0.4.0"
+  version = "~> 0.9.0"
 
   project_id = var.project_id
   region     = "us-central1"

--- a/examples/backend-with-psc-neg/main.tf
+++ b/examples/backend-with-psc-neg/main.tf
@@ -135,7 +135,7 @@ module "psc-neg-subnet" {
 
 module "lb-backend-psc-neg" {
   source  = "GoogleCloudPlatform/regional-lb-http/google//modules/backend"
-  version = "~> 0.4.0"
+  version = "~> 0.9.0"
 
   project_id            = var.project_id
   name                  = "backend-with-psc-neg"

--- a/modules/frontend/metadata.yaml
+++ b/modules/frontend/metadata.yaml
@@ -65,6 +65,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
+              version: ">= 17.1.0"
             spec:
               outputExpr: network_name
       - name: subnetwork
@@ -73,6 +74,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
+              version: ">= 17.1.0"
             spec:
               outputExpr: subnets_names[0]
       - name: create_proxy_only_subnet

--- a/modules/frontend/metadata.yaml
+++ b/modules/frontend/metadata.yaml
@@ -62,9 +62,19 @@ spec:
         description: VPC network for the forwarding rule. It should not be default. The VPC network should have only one REGIONAL_MANAGED_PROXY subnetwork in the same region as of this regional load balancer. Please go to the subnets tab of your VPC network and check if a REGIONAL_MANAGED_PROXY subnet exists under `Reserved proxy-only subnets for load balancing` section. If the REGIONAL_MANAGED_PROXY doesn't exists, set create_proxy_only_subnet parameter to provision it as part of this component deployment.
         varType: string
         required: true
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network
+            spec:
+              outputExpr: network_name
       - name: subnetwork
         description: Subnetwork that the load balanced IP should belong to, used in internal load balancing
         varType: string
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network
+            spec:
+              outputExpr: subnets_names[0]
       - name: create_proxy_only_subnet
         description: Create a REGIONAL_MANAGED_PROXY subnetwork in the provided VPC network.
         varType: bool


### PR DESCRIPTION
Adding missing VPC connection for Regional LB Frontend.

Testing Steps for VPC Connection:

1) Ingest Component Revision (BYOC):
- Set the gcloud configuration to point to the Staging environment.
- Create the template metadata for the Regional LB Frontend component.
- Create a template revision to pull our specific code tag (e.g., v0.9.0) into the private catalog.

2) UI Verification (ADC Canvas):

- Navigate to the [Pantheon Staging environment]. Ensure that Coliseum environment is set to STAGING and config is set to PROD in Backend Overrides.
- In the ADC canvas, drag and drop the custom Regional LB Frontend and VPC components.
- Verify the connection: Drag a connection line between the two. The connection should automatically snap to the network and subnetwork variables, and the connections parameters must be populated.
- Add dependency component - Regional LB Backend and establish its connection with Regional LB Frontend.
- Fill all required configuration parameters for all 3 components (e.g., region, project, name, network and subnet details, etc)

3) Deployment Verification:
- Create a new application with the connected components.
- Click Preview and confirm that the Terraform Plan generates without errors.
- Click Deploy and ensure the application deployment completes successfully.

Successful testing in Staging environment:
https://screenshot.googleplex.com/7EF32j9cmY9UHNH