### PR TITLE
feat: Downgrade version requirement for terraform-google-network

### DIFF
--- a/modules/frontend/metadata.yaml
+++ b/modules/frontend/metadata.yaml
@@ -65,7 +65,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: ">= 17.1.0"
+              version: ">= 16.0.1"
             spec:
               outputExpr: network_name
       - name: subnetwork
@@ -74,7 +74,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: ">= 17.1.0"
+              version: ">= 16.0.1"
             spec:
               outputExpr: subnets_names[0]
       - name: create_proxy_only_subnet


### PR DESCRIPTION
Downgrade VPC version for Regional LB Frontend module.

Testing Steps for VPC Connection:

1) Ingest Component Revision (BYOC):

- Set the gcloud configuration to point to the Staging environment.
- Create the template metadata for the Regional LB Frontend component.
- Create a template revision to pull our specific code tag (e.g., v0.11.0) into the private catalog.

2) UI Verification (ADC Canvas):

- Navigate to the [Pantheon Staging environment]. Ensure that Coliseum environment is set to STAGING and config is set to PROD in Backend Overrides.
- In the ADC canvas, drag and drop the custom Regional LB Frontend and VPC components.
- Verify the connection: Drag a connection line between the two. The connection should automatically snap to the network and subnetwork variables, and the connections parameters must be populated.
- Add dependency component - Regional LB Backend and establish its connection with Regional LB Frontend.
- Fill all required configuration parameters for all 3 components (e.g., region, project, name, network and subnet details, etc)

3) Deployment Verification:

- Create a new application with the connected components.
- Click Preview and confirm that the Terraform Plan generates without errors.
- Click Deploy and ensure the application deployment completes successfully.

Successful testing in Staging environment:
https://screenshot.googleplex.com/9fzGgJmVTCxJEn2